### PR TITLE
Add usrsctp_get_timeout()

### DIFF
--- a/usrsctplib/netinet/sctp_callout.h
+++ b/usrsctplib/netinet/sctp_callout.h
@@ -87,6 +87,7 @@ void sctp_os_timer_init(sctp_os_timer_t *tmr);
 int sctp_os_timer_start(sctp_os_timer_t *, uint32_t, void (*)(void *), void *);
 /* Returns 1 if pending timer was stopped, 0 otherwise. */
 int sctp_os_timer_stop(sctp_os_timer_t *);
+int64_t sctp_get_next_tick(void);
 void sctp_handle_tick(uint32_t);
 
 #define SCTP_OS_TIMER_INIT	sctp_os_timer_init

--- a/usrsctplib/user_socket.c
+++ b/usrsctplib/user_socket.c
@@ -3331,6 +3331,12 @@ usrsctp_conninput(void *addr, const void *buffer, size_t length, uint8_t ecn_bit
 	return;
 }
 
+int64_t
+usrsctp_get_timeout(void)
+{
+	return sctp_get_next_tick();
+}
+
 void usrsctp_handle_timers(uint32_t elapsed_milliseconds)
 {
 	sctp_handle_tick(sctp_msecs_to_ticks(elapsed_milliseconds));

--- a/usrsctplib/usrsctp.h
+++ b/usrsctplib/usrsctp.h
@@ -1049,6 +1049,8 @@ usrsctp_set_upcall(struct socket *so,
 int
 usrsctp_get_events(struct socket *so);
 
+int64_t
+usrsctp_get_timeout(void);
 
 void
 usrsctp_handle_timers(uint32_t elapsed_milliseconds);


### PR DESCRIPTION
Same as PR https://github.com/sctplab/usrsctp/pull/591 by @oleavr in upstream project which has been ignored for 4 years.

A little change: Instead of using `int` to hold a `uint32_t` (or -1) let's use a `int64_t`.